### PR TITLE
Add convenience for running import-papers script

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ A user is considered as an admin if they are a part of the team `GH_ORG_TEAM_SLU
 1. Change directory to `crawler/` and run `go mod tidy`.
 2. Run the crawler by running `go run crawler.go`. (Make sure you are connected to the campus network)
 3. This will generate a `qp.tar.gz` file. Transfer this file to the server's `backend/` folder.
-4. In the backend, run `cargo run --bin import-papers` to import the data into the database. (Make sure the database is set up and running)
+4. (Development): In the backend, run `cargo run --bin import-papers` to import the data into the database. (Make sure the database is set up and running)\
+    (Production): In the backend, run `./import_papers.sh ./qp.tar.gz` to run the import script in the docker container running the application.
 
 ## Deployment
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,5 +28,6 @@ COPY metaploy/ ./
 RUN chmod +x ./postinstall.sh
 
 COPY --from=builder /src/target/x86_64-unknown-linux-musl/release/iqps-backend .
+COPY --from=builder /src/target/x86_64-unknown-linux-musl/release/import-papers .
 
 CMD ["./postinstall.sh", "./iqps-backend"]

--- a/backend/import_papers.sh
+++ b/backend/import_papers.sh
@@ -7,17 +7,13 @@ if [[ $# -ne 1 ]]; then
 fi
 
 ARCHIVE_PATH="$1"
-BASENAME="$(basename "$ARCHIVE_PATH")"
-DEST_PATH="/tmp/$BASENAME"
 SERVICE="iqps-backend"
+DEST_PATH="/app/qp.tar.gz"
 
-echo "Copying '$ARCHIVE_PATH' to service '$SERVICE'..."
+echo "📦 Copying '$ARCHIVE_PATH' to '$SERVICE'..."
 docker compose cp "$ARCHIVE_PATH" "$SERVICE":"$DEST_PATH"
 
-echo "Running import-papers on '$DEST_PATH'..."
-docker compose exec "$SERVICE" ./import-papers "$DEST_PATH"
+echo "⚙️ Running import-papers..."
+docker compose exec "$SERVICE" ./import-papers
 
-echo "Cleaning up temporary file in container..."
-docker compose exec "$SERVICE" rm -f "$DEST_PATH"
-
-echo "Done!"
+echo "✅ Done!"

--- a/backend/import_papers.sh
+++ b/backend/import_papers.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <file.tar.gz>"
+    exit 1
+fi
+
+ARCHIVE_PATH="$1"
+BASENAME="$(basename "$ARCHIVE_PATH")"
+DEST_PATH="/tmp/$BASENAME"
+SERVICE="iqps-backend"
+
+echo "Copying '$ARCHIVE_PATH' to service '$SERVICE'..."
+docker compose cp "$ARCHIVE_PATH" "$SERVICE":"$DEST_PATH"
+
+echo "Running import-papers on '$DEST_PATH'..."
+docker compose exec "$SERVICE" ./import-papers "$DEST_PATH"
+
+echo "Cleaning up temporary file in container..."
+docker compose exec "$SERVICE" rm -f "$DEST_PATH"
+
+echo "Done!"

--- a/backend/import_papers.sh
+++ b/backend/import_papers.sh
@@ -10,10 +10,10 @@ ARCHIVE_PATH="$1"
 SERVICE="iqps-backend"
 DEST_PATH="/app/qp.tar.gz"
 
-echo "📦 Copying '$ARCHIVE_PATH' to '$SERVICE'..."
+echo "Copying '$ARCHIVE_PATH' to '$SERVICE'..."
 docker compose cp "$ARCHIVE_PATH" "$SERVICE":"$DEST_PATH"
 
-echo "⚙️ Running import-papers..."
+echo "Running import-papers..."
 docker compose exec "$SERVICE" ./import-papers
 
-echo "✅ Done!"
+echo "Done!"


### PR DESCRIPTION
# Description
The `import-papers` script is supposed to take a gzipped archive of question papers and upload them to the database (and filestore). In production, the app is run as a docker image, whose container doesn't have this binary. This PR adds this binary to the Dockerfile; and also adds a shell script which can be run to copy the archive into the container, and run the binary in the container.

- [x] I have updated the relevant documentation
