### PR TITLE
Improvements to import script and other changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ go.work.sum
 frontend/public/pdf.worker.min.mjs
 *.log
 *.patch
+log

--- a/backend/import_papers.sh
+++ b/backend/import_papers.sh
@@ -10,10 +10,18 @@ ARCHIVE_PATH="$1"
 SERVICE="iqps-backend"
 DEST_PATH="/app/qp.tar.gz"
 
+if [[ ! -f "$ARCHIVE_PATH" ]]; then
+    echo "Error: File '$ARCHIVE_PATH' not found."
+    exit 1
+fi
+
 echo "Copying '$ARCHIVE_PATH' to '$SERVICE'..."
 docker compose cp "$ARCHIVE_PATH" "$SERVICE":"$DEST_PATH"
 
 echo "Running import-papers..."
 docker compose exec "$SERVICE" ./import-papers
+
+echo "Deleting copied file from container..."
+docker compose exec "$SERVICE" rm -f "$DEST_PATH"
 
 echo "Done!"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Read environment variables
-    let env_vars = env::EnvVars::parse().process()?;
+    let env_vars = env::EnvVars::parse()?.process()?;
 
     // Initialize logger
     let (append_writer, _guard) = tracing_appender::non_blocking(

--- a/frontend/src/components/Common/Common.tsx
+++ b/frontend/src/components/Common/Common.tsx
@@ -4,7 +4,10 @@ import './styles/common_styles.scss';
 import { IconType } from 'react-icons';
 
 export function Footer() {
-	return <h3 className="meta-footer">Made with ❤️ and {"</>"} by <a href="https://github.com/metakgp/iqps-go" target="_blank">MetaKGP</a></h3>;
+	return <h3 className="meta-footer">
+        Contribute on <a href="https://github.com/metakgp/iqps-go" target="_blank">GitHub</a> | 
+        Made with ❤️ and {"</>"} by <a href="https://github.com/metakgp" target="_blank">MetaKGP</a>
+    </h3>;
 }
 
 interface ILinkCommonProps {


### PR DESCRIPTION

# Description

- Manually parsing env instead of using `clap`
- `import-papers` (rust script): Added a CLI argument to specify the filename for the archive. Also has a help command (via `clap`)
- `import_papers.sh` (bash script): Deleted the copied archive file from the container after processing
- Frontend: Added 'Contribute on GitHub' to footer


- [x] I have updated the relevant documentation
