### PR TITLE
Rewriting Old Dumb Code

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -267,6 +267,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -106,17 +106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,13 +122,13 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.7.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
+checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -153,12 +142,11 @@ dependencies = [
  "multer",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
@@ -168,20 +156,18 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -506,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -893,7 +879,7 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -1030,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libm"
@@ -1086,9 +1072,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -1433,7 +1419,7 @@ checksum = "4fe68c2e9e1a1234e218683dbdf9f9dfcb094113c5ac2b938dfcb9bab4c4140b"
 dependencies = [
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.7",
  "windows-sys 0.59.0",
 ]
 
@@ -1515,7 +1501,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1628,12 +1614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,18 +1627,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1679,12 +1669,13 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
  "itoa",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1781,6 +1772,16 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2035,20 +2036,14 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -2162,27 +2157,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.1",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2213,14 +2207,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -2579,6 +2573,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,6 +2636,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,11 +2677,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2679,6 +2714,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,6 +2730,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2703,10 +2750,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2721,6 +2780,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,6 +2796,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2745,6 +2816,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,6 +2832,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -4,9 +4,12 @@ version = "0.1.0"
 edition = "2021"
 default-run = "iqps-backend"
 
+[build]
+rustdocflags = ["--document-private-items"]
+
 [dependencies]
 axum = { version = "0.8.6", features = ["multipart"] }
-chrono = "0.4.38"
+chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.20", features = ["derive", "env"] }
 color-eyre = "0.6.3"
 dotenvy = "0.15.7"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 default-run = "iqps-backend"
 
 [dependencies]
-axum = { version = "0.7.7", features = ["multipart"] }
+axum = { version = "0.8.6", features = ["multipart"] }
 chrono = "0.4.38"
 clap = { version = "4.5.20", features = ["derive", "env"] }
 color-eyre = "0.6.3"

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -22,7 +22,7 @@ pub struct Auth {
 ///
 /// Returns the username and jwt in a struct
 pub async fn verify_token(
-    token: &str,
+    token: String,
     env_vars: &EnvVars,
 ) -> Result<Auth, color_eyre::eyre::Error> {
     let jwt_key = env_vars.get_jwt_key()?;
@@ -38,7 +38,7 @@ pub async fn verify_token(
         .ok_or(eyre!("Username is not a string."))?;
 
     Ok(Auth {
-        jwt: token.to_owned(),
+        jwt: token,
         username: username.to_owned(),
     })
 }
@@ -100,7 +100,7 @@ struct GithubMembershipResponse {
 ///
 /// Returns the JWT if the user is authenticated, `None` otherwise.
 pub async fn authenticate_user(
-    code: &String,
+    code: &str,
     env_vars: &EnvVars,
 ) -> Result<Option<String>, color_eyre::eyre::Error> {
     let client = reqwest::Client::new();
@@ -130,6 +130,8 @@ pub async fn authenticate_user(
             .context("Error parsing access token response.")?
             .access_token;
 
+    println!("Access token: {access_token}");
+
     // Get the username of the user who made the request
     let response = client
         .get("https://api.github.com/user")
@@ -152,6 +154,8 @@ pub async fn authenticate_user(
         .context("Error parsing username API response.")?
         .login;
 
+    println!("Username: {username}");
+
     // Check if the user is in the admin list
     if env_vars
         .gh_admin_usernames
@@ -172,10 +176,7 @@ pub async fn authenticate_user(
             "https://api.github.com/orgs/{}/teams/{}/memberships/{}",
             env_vars.gh_org_name, env_vars.gh_org_team_slug, username
         ))
-        .header(
-            "Authorization",
-            format!("Bearer {}", access_token),
-        )
+        .header("Authorization", format!("Bearer {}", access_token))
         .header("User-Agent", "bruh why is this required")
         .send()
         .await

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -130,8 +130,6 @@ pub async fn authenticate_user(
             .context("Error parsing access token response.")?
             .access_token;
 
-    println!("Access token: {access_token}");
-
     // Get the username of the user who made the request
     let response = client
         .get("https://api.github.com/user")
@@ -153,8 +151,6 @@ pub async fn authenticate_user(
     let username = serde_json::from_slice::<GithubUserResponse>(&response.bytes().await?)
         .context("Error parsing username API response.")?
         .login;
-
-    println!("Username: {username}");
 
     // Check if the user is in the admin list
     if env_vars

--- a/backend/src/bin/import-papers.rs
+++ b/backend/src/bin/import-papers.rs
@@ -99,7 +99,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let file_path = dir_path.join(format!("qp/{}", qp.filename)); // TODO use consistent format
         let hash = hash_file(&file_path).expect("Failed to hash file");
 
-        let mut similar_papers = database
+        let similar_papers = database
             .get_similar_papers(
                 &qp.course_code,
                 Some(qp.year),
@@ -109,7 +109,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await?;
 
         if qp.approve_status {
-            if let Some(similar) = similar_papers.next() {
+            if let Some(similar) = similar_papers.first() {
                 // todo: what if there are multiple similar papers?
                 if similar.qp.from_library {
                     // check pdf hash

--- a/backend/src/bin/import-papers.rs
+++ b/backend/src/bin/import-papers.rs
@@ -109,7 +109,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await?;
 
         if qp.approve_status {
-            if let Some(similar) = similar_papers.first() {
+            if let Some(similar) = similar_papers.next() {
                 // todo: what if there are multiple similar papers?
                 if similar.qp.from_library {
                     // check pdf hash

--- a/backend/src/bin/import-papers.rs
+++ b/backend/src/bin/import-papers.rs
@@ -99,7 +99,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let file_path = dir_path.join(format!("qp/{}", qp.filename)); // TODO use consistent format
         let hash = hash_file(&file_path).expect("Failed to hash file");
 
-        let similar_papers = database
+        let mut similar_papers = database
             .get_similar_papers(
                 &qp.course_code,
                 Some(qp.year),

--- a/backend/src/bin/import-papers.rs
+++ b/backend/src/bin/import-papers.rs
@@ -35,12 +35,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .process()
         .expect("Failed to parse environment variables");
 
-	let args = Args::parse();
-	if !Path::new(&args.file).exists() {
-		eprintln!("Error: file '{}' not found.", args.file);
-		std::process::exit(1);
-	}
-	
+    let args = Args::parse();
+    if !Path::new(&args.file).exists() {
+        eprintln!("Error: file '{}' not found.", args.file);
+        std::process::exit(1);
+    }
+
     let database = db::Database::new(&env_vars)
         .await
         .expect("Failed to connect to database");
@@ -157,7 +157,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             break;
         }
     }
-    
+
     println!("Finished uploading papers to database.");
     dir.close()?;
 
@@ -167,10 +167,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
       "💥 {count} papers have been imported into IQPS!\n\n<https://qp.metakgp.org/admin|Review> | Total Unapproved papers: *{total_count}*",
     );
 
-    let _ = slack::send_slack_message(
-      &env_vars.slack_webhook_url,
-      &message,
-    ).await;
+    let _ = slack::send_slack_message(&env_vars.slack_webhook_url, &message).await;
 
     Ok(())
 }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1,7 +1,6 @@
 //! Database stuff. See submodules also.
 
 use color_eyre::eyre::eyre;
-use models::DBAdminDashboardQP;
 use sqlx::{postgres::PgPoolOptions, prelude::FromRow, PgPool, Postgres, Transaction};
 use std::time::Duration;
 
@@ -50,15 +49,13 @@ impl Database {
     }
 
     /// Fetches the list of all unapproved papers
-    pub async fn get_unapproved_papers(
-        &self,
-    ) -> Result<impl Iterator<Item = qp::AdminDashboardQP>, sqlx::Error> {
+    pub async fn get_unapproved_papers(&self) -> Result<Vec<qp::AdminDashboardQP>, sqlx::Error> {
         let query_sql = queries::get_all_unapproved_query();
-        let papers: Vec<models::DBAdminDashboardQP> = sqlx::query_as(&query_sql)
+        let papers: Vec<qp::AdminDashboardQP> = sqlx::query_as(&query_sql)
             .fetch_all(&self.connection)
             .await?;
 
-        Ok(papers.into_iter().map(qp::AdminDashboardQP::from))
+        Ok(papers)
     }
 
     /// Returns the number of unapproved papers
@@ -79,18 +76,18 @@ impl Database {
         let query_sql = queries::get_qp_search_query(exam_filter);
         let query = sqlx::query_as(&query_sql).bind(query);
 
-        let papers: Vec<models::DBBaseQP> = query.fetch_all(&self.connection).await?;
+        let papers: Vec<qp::BaseQP> = query.fetch_all(&self.connection).await?;
 
-        Ok(papers.into_iter().map(qp::BaseQP::from))
+        Ok(papers.into_iter())
     }
 
     pub async fn get_paper_by_id(&self, id: i32) -> Result<qp::AdminDashboardQP, sqlx::Error> {
         let query_sql = queries::get_get_paper_by_id_query();
         let query = sqlx::query_as(&query_sql).bind(id);
 
-        let paper: models::DBAdminDashboardQP = query.fetch_one(&self.connection).await?;
+        let paper: qp::AdminDashboardQP = query.fetch_one(&self.connection).await?;
 
-        Ok(paper.into())
+        Ok(paper)
     }
 
     /// Edit's a paper's details.
@@ -183,8 +180,7 @@ impl Database {
             query
         };
 
-        let new_qp: DBAdminDashboardQP = query.fetch_one(&mut *tx).await?;
-        let new_qp = AdminDashboardQP::from(new_qp);
+        let new_qp: AdminDashboardQP = query.fetch_one(&mut *tx).await?;
 
         // Delete the replaced papers
         for replace_id in replace {
@@ -231,15 +227,13 @@ impl Database {
     }
 
     /// Gets all soft-deleted papers from the database
-    pub async fn get_soft_deleted_papers(
-        &self,
-    ) -> Result<impl Iterator<Item = AdminDashboardQP>, sqlx::Error> {
+    pub async fn get_soft_deleted_papers(&self) -> Result<Vec<AdminDashboardQP>, sqlx::Error> {
         let query_sql = queries::get_get_soft_deleted_papers_query();
-        let papers: Vec<models::DBAdminDashboardQP> = sqlx::query_as(&query_sql)
+        let papers: Vec<AdminDashboardQP> = sqlx::query_as(&query_sql)
             .fetch_all(&self.connection)
             .await?;
 
-        Ok(papers.into_iter().map(qp::AdminDashboardQP::from))
+        Ok(papers)
     }
 
     /// Permanently deletes a paper from the database
@@ -273,7 +267,7 @@ impl Database {
         year: Option<i32>,
         semester: Option<&String>,
         exam: Option<&String>,
-    ) -> Result<impl Iterator<Item = AdminDashboardQP>, sqlx::Error> {
+    ) -> Result<Vec<AdminDashboardQP>, sqlx::Error> {
         let query_sql =
             queries::get_similar_papers_query(year.is_some(), semester.is_some(), exam.is_some());
         let query = sqlx::query_as(&query_sql).bind(course_code);
@@ -282,9 +276,9 @@ impl Database {
         let query = query.bind(semester);
         let query = query.bind(exam);
 
-        let papers: Vec<models::DBAdminDashboardQP> = query.fetch_all(&self.connection).await?;
+        let papers: Vec<qp::AdminDashboardQP> = query.fetch_all(&self.connection).await?;
 
-        Ok(papers.into_iter().map(qp::AdminDashboardQP::from))
+        Ok(papers)
     }
 
     /// Inserts a new uploaded question paper into the database. Uses a placeholder for the filelink which should be replaced once the id is known using the [crate::db::Database::update_filelink] function.

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -72,13 +72,13 @@ impl Database {
         &self,
         query: &str,
         exam_filter: Vec<Exam>,
-    ) -> Result<impl Iterator<Item = qp::BaseQP>, sqlx::Error> {
+    ) -> Result<Vec<qp::BaseQP>, sqlx::Error> {
         let query_sql = queries::get_qp_search_query(exam_filter);
         let query = sqlx::query_as(&query_sql).bind(query);
 
         let papers: Vec<qp::BaseQP> = query.fetch_all(&self.connection).await?;
 
-        Ok(papers.into_iter())
+        Ok(papers)
     }
 
     pub async fn get_paper_by_id(&self, id: i32) -> Result<qp::AdminDashboardQP, sqlx::Error> {

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -99,12 +99,12 @@ impl Database {
     /// - Deletes `replace` papers from the database.
     ///
     /// Returns the database transaction, the old filelink and the new paper details ([`crate::qp::AdminDashboardQP`])
-    pub async fn edit_paper<'c>(
+    pub async fn edit_paper(
         &self,
         edit_req: EditReq,
         username: &str,
         env_vars: &EnvVars,
-    ) -> Result<(Transaction<'c, Postgres>, String, AdminDashboardQP), color_eyre::eyre::Error>
+    ) -> Result<(Transaction<'_, Postgres>, String, AdminDashboardQP), color_eyre::eyre::Error>
     {
         let EditReq {
             id,

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -204,15 +204,6 @@ impl Database {
         Ok((tx, old_filelink, new_qp))
     }
 
-    // /// Adds a new upload paper's details to the database. Sets the `from_library` field to false.
-    // ///
-    // /// Returns the database transaction and the id of the uploaded paper
-    // pub async fn add_uploaded_paper<'c>(
-    //     &self,
-    //     file_details:
-    // ) -> Result<(Transaction<'c, Postgres>, i32), color_eyre::eyre::Error> {
-    // }
-
     /// Sets the `is_deleted` field to true and `approve_status` to false. Only deletes uploaded papers.
     ///
     /// Returns a boolean that represents whether a db entry was affected or not. If more than one entry was affected, an error will be thrown and the transaction will be rolled back.
@@ -326,7 +317,6 @@ impl Database {
         Ok((tx, id))
     }
 
-    #[allow(unused)]
     /// Inserts a new library question paper into the database. Uses a placeholder for the filelink which should be replaced once the id is known using the [crate::db::Database::update_filelink] function.
     ///
     /// Returns a tuple with the transaction and the id of the inserted paper.

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -15,7 +15,6 @@ use crate::{
 mod models;
 mod queries;
 
-#[derive(Clone)]
 /// The database
 pub struct Database {
     connection: PgPool,
@@ -57,10 +56,7 @@ impl Database {
             .fetch_all(&self.connection)
             .await?;
 
-        Ok(papers
-            .iter()
-            .map(|qp| qp::AdminDashboardQP::from(qp.clone()))
-            .collect())
+        Ok(papers.into_iter().map(qp::AdminDashboardQP::from).collect())
     }
 
     /// Returns the number of unapproved papers
@@ -83,10 +79,7 @@ impl Database {
 
         let papers: Vec<models::DBBaseQP> = query.fetch_all(&self.connection).await?;
 
-        Ok(papers
-            .iter()
-            .map(|qp| qp::BaseQP::from(qp.clone()))
-            .collect())
+        Ok(papers.into_iter().map(qp::BaseQP::from).collect())
     }
 
     pub async fn get_paper_by_id(&self, id: i32) -> Result<qp::AdminDashboardQP, sqlx::Error> {
@@ -132,22 +125,25 @@ impl Database {
         let course_code = course_code.unwrap_or(current_details.qp.course_code);
         let course_name = course_name.unwrap_or(current_details.qp.course_name);
         let year = year.unwrap_or(current_details.qp.year);
-        let semester: String = semester
-            .map(|sem| Semester::try_from(&sem))
-            .transpose()?
-            .unwrap_or(current_details.qp.semester)
-            .into();
-        let exam: String = exam
-            .map(|exam| Exam::try_from(&exam))
-            .transpose()?
-            .unwrap_or(current_details.qp.exam)
-            .into();
+        let semester: String = String::from(
+            &semester
+                .map(|sem| Semester::try_from(sem.as_str()))
+                .transpose()?
+                .unwrap_or(current_details.qp.semester),
+        );
+        let exam: String = String::from(
+            &exam
+                .map(|exam| Exam::try_from(exam.as_str()))
+                .transpose()?
+                .unwrap_or(current_details.qp.exam),
+        );
         let approve_status = approve_status.unwrap_or(current_details.approve_status);
 
         // Set the new filelink
         let old_filelink = current_details.qp.filelink;
+
         let new_filelink = if current_details.qp.from_library {
-            old_filelink.clone() // TODO use consistent format
+            old_filelink.clone()
         } else if approve_status {
             env_vars.paths.get_slug(
                 &format!(
@@ -248,10 +244,7 @@ impl Database {
             .fetch_all(&self.connection)
             .await?;
 
-        Ok(papers
-            .iter()
-            .map(|qp| qp::AdminDashboardQP::from(qp.clone()))
-            .collect())
+        Ok(papers.into_iter().map(qp::AdminDashboardQP::from).collect())
     }
 
     /// Permanently deletes a paper from the database
@@ -296,10 +289,7 @@ impl Database {
 
         let papers: Vec<models::DBAdminDashboardQP> = query.fetch_all(&self.connection).await?;
 
-        Ok(papers
-            .iter()
-            .map(|qp| qp::AdminDashboardQP::from(qp.clone()))
-            .collect())
+        Ok(papers.into_iter().map(qp::AdminDashboardQP::from).collect())
     }
 
     /// Inserts a new uploaded question paper into the database. Uses a placeholder for the filelink which should be replaced once the id is known using the [crate::db::Database::update_filelink] function.
@@ -307,7 +297,7 @@ impl Database {
     /// Returns a tuple with the transaction and the id of the inserted paper.
     pub async fn insert_new_uploaded_qp<'c>(
         &self,
-        file_details: &FileDetails,
+        file_details: FileDetails,
     ) -> Result<(Transaction<'c, Postgres>, i32), color_eyre::eyre::Error> {
         let mut tx = self.connection.begin().await?;
 

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -50,13 +50,15 @@ impl Database {
     }
 
     /// Fetches the list of all unapproved papers
-    pub async fn get_unapproved_papers(&self) -> Result<Vec<qp::AdminDashboardQP>, sqlx::Error> {
+    pub async fn get_unapproved_papers(
+        &self,
+    ) -> Result<impl Iterator<Item = qp::AdminDashboardQP>, sqlx::Error> {
         let query_sql = queries::get_all_unapproved_query();
         let papers: Vec<models::DBAdminDashboardQP> = sqlx::query_as(&query_sql)
             .fetch_all(&self.connection)
             .await?;
 
-        Ok(papers.into_iter().map(qp::AdminDashboardQP::from).collect())
+        Ok(papers.into_iter().map(qp::AdminDashboardQP::from))
     }
 
     /// Returns the number of unapproved papers
@@ -73,13 +75,13 @@ impl Database {
         &self,
         query: &str,
         exam_filter: Vec<Exam>,
-    ) -> Result<Vec<qp::BaseQP>, sqlx::Error> {
+    ) -> Result<impl Iterator<Item = qp::BaseQP>, sqlx::Error> {
         let query_sql = queries::get_qp_search_query(exam_filter);
         let query = sqlx::query_as(&query_sql).bind(query);
 
         let papers: Vec<models::DBBaseQP> = query.fetch_all(&self.connection).await?;
 
-        Ok(papers.into_iter().map(qp::BaseQP::from).collect())
+        Ok(papers.into_iter().map(qp::BaseQP::from))
     }
 
     pub async fn get_paper_by_id(&self, id: i32) -> Result<qp::AdminDashboardQP, sqlx::Error> {
@@ -229,13 +231,15 @@ impl Database {
     }
 
     /// Gets all soft-deleted papers from the database
-    pub async fn get_soft_deleted_papers(&self) -> Result<Vec<AdminDashboardQP>, sqlx::Error> {
+    pub async fn get_soft_deleted_papers(
+        &self,
+    ) -> Result<impl Iterator<Item = AdminDashboardQP>, sqlx::Error> {
         let query_sql = queries::get_get_soft_deleted_papers_query();
         let papers: Vec<models::DBAdminDashboardQP> = sqlx::query_as(&query_sql)
             .fetch_all(&self.connection)
             .await?;
 
-        Ok(papers.into_iter().map(qp::AdminDashboardQP::from).collect())
+        Ok(papers.into_iter().map(qp::AdminDashboardQP::from))
     }
 
     /// Permanently deletes a paper from the database
@@ -269,7 +273,7 @@ impl Database {
         year: Option<i32>,
         semester: Option<&String>,
         exam: Option<&String>,
-    ) -> Result<Vec<AdminDashboardQP>, sqlx::Error> {
+    ) -> Result<impl Iterator<Item = AdminDashboardQP>, sqlx::Error> {
         let query_sql =
             queries::get_similar_papers_query(year.is_some(), semester.is_some(), exam.is_some());
         let query = sqlx::query_as(&query_sql).bind(course_code);
@@ -280,7 +284,7 @@ impl Database {
 
         let papers: Vec<models::DBAdminDashboardQP> = query.fetch_all(&self.connection).await?;
 
-        Ok(papers.into_iter().map(qp::AdminDashboardQP::from).collect())
+        Ok(papers.into_iter().map(qp::AdminDashboardQP::from))
     }
 
     /// Inserts a new uploaded question paper into the database. Uses a placeholder for the filelink which should be replaced once the id is known using the [crate::db::Database::update_filelink] function.

--- a/backend/src/db/models.rs
+++ b/backend/src/db/models.rs
@@ -9,7 +9,7 @@ use crate::qp::Semester;
 use super::qp;
 use sqlx::{prelude::FromRow, types::chrono};
 
-#[derive(FromRow, Clone)]
+#[derive(FromRow)]
 /// Base/common fields of a question paper
 pub struct DBBaseQP {
     id: i32,
@@ -23,7 +23,7 @@ pub struct DBBaseQP {
     note: String,
 }
 
-#[derive(FromRow, Clone)]
+#[derive(FromRow)]
 /// The fields of a question paper sent to the admin dashboard endpoint
 pub struct DBAdminDashboardQP {
     #[sqlx(flatten)]
@@ -51,8 +51,12 @@ impl From<DBBaseQP> for qp::BaseQP {
             course_code: value.course_code,
             course_name: value.course_name,
             year: value.year,
-            semester: (&value.semester).try_into().unwrap_or(Semester::Unknown),
-            exam: (&value.exam).try_into().unwrap_or(qp::Exam::Unknown),
+            semester: value
+                .semester
+                .as_str()
+                .try_into()
+                .unwrap_or(Semester::Unknown),
+            exam: value.exam.as_str().try_into().unwrap_or(qp::Exam::Unknown),
             note: value.note,
         }
     }

--- a/backend/src/db/models.rs
+++ b/backend/src/db/models.rs
@@ -1,63 +1,42 @@
-//! Database models.
-//!
-//! These can be (should be) converted to the structs in [`crate::qp`] for sending as a response since the struct also parses the `semester` and `exam` fields and also generates the full static files URL.
-//!
-//! Use the [`From`] trait implementations.
+use duplicate::duplicate_item;
+use sqlx::{postgres::PgTypeInfo, Postgres};
 
-use crate::qp::Semester;
+use crate::qp::{Exam, Semester};
 
-use super::qp;
-use sqlx::{prelude::FromRow, types::chrono};
-
-#[derive(FromRow)]
-/// Base/common fields of a question paper
-pub struct DBBaseQP {
-    id: i32,
-    filelink: String,
-    from_library: bool,
-    course_code: String,
-    course_name: String,
-    year: i32,
-    semester: String,
-    exam: String,
-    note: String,
-}
-
-#[derive(FromRow)]
-/// The fields of a question paper sent to the admin dashboard endpoint
-pub struct DBAdminDashboardQP {
-    #[sqlx(flatten)]
-    qp: DBBaseQP,
-    upload_timestamp: chrono::NaiveDateTime,
-    approve_status: bool,
-}
-
-impl From<DBAdminDashboardQP> for qp::AdminDashboardQP {
-    fn from(value: DBAdminDashboardQP) -> Self {
-        Self {
-            qp: value.qp.into(),
-            upload_timestamp: value.upload_timestamp.to_string(),
-            approve_status: value.approve_status,
-        }
+// DO NOT ASK ME WHAT THE BELOW TRAIT IMPLEMENTATIONS DO
+// I JUST KNOW THEY ARE NEEDED TO TEACH SQLX HOW TO DECODE AND ENCODE THIS SHIT
+impl sqlx::Type<Postgres> for Exam {
+    fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
+        <String as sqlx::Type<Postgres>>::type_info()
     }
 }
 
-impl From<DBBaseQP> for qp::BaseQP {
-    fn from(value: DBBaseQP) -> Self {
-        Self {
-            id: value.id,
-            filelink: value.filelink,
-            from_library: value.from_library,
-            course_code: value.course_code,
-            course_name: value.course_name,
-            year: value.year,
-            semester: value
-                .semester
-                .as_str()
-                .try_into()
-                .unwrap_or(Semester::Unknown),
-            exam: value.exam.as_str().try_into().unwrap_or(qp::Exam::Unknown),
-            note: value.note,
-        }
+impl sqlx::Type<Postgres> for Semester {
+    fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
+        // Yes the init sql in queries.rs sets the type to `TEXT` but turns out the database has
+        // `VARCHAR` type so idk what to do here
+        PgTypeInfo::with_name("VARCHAR")
+    }
+}
+
+#[duplicate_item(
+    DBEncodeDecode;
+    [ Exam ];
+    [ Semester ];
+)]
+impl sqlx::Decode<'_, sqlx::Postgres> for DBEncodeDecode {
+    fn decode(
+        value: <sqlx::Postgres as sqlx::Database>::ValueRef<'_>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        Ok(Self::try_from(value.as_str()?)?)
+    }
+}
+
+impl<'q> sqlx::Encode<'q, Postgres> for Exam {
+    fn encode_by_ref(
+        &self,
+        buf: &mut <Postgres as sqlx::Database>::ArgumentBuffer<'q>,
+    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+        <String as sqlx::Encode<'q, Postgres>>::encode_by_ref(&String::from(self), buf)
     }
 }

--- a/backend/src/db/queries.rs
+++ b/backend/src/db/queries.rs
@@ -61,10 +61,6 @@ pub fn get_similar_papers_query(year: bool, semester: bool, exam: bool) -> Strin
     )
 }
 
-/// Soft deletes a paper (sets `approve_status` to false and `is_deleted` to true) of an uploaded paper.
-pub const SOFT_DELETE_BY_ID: &str =
-    "UPDATE iqps SET approve_status=false, is_deleted = true WHERE id=$1 AND from_library = false";
-
 /// Soft deletes a paper (sets `approve_status` to false and `is_deleted` to true) of any paper.
 pub const SOFT_DELETE_ANY_BY_ID: &str =
     "UPDATE iqps SET approve_status=false, is_deleted = true WHERE id=$1";

--- a/backend/src/db/queries.rs
+++ b/backend/src/db/queries.rs
@@ -70,12 +70,14 @@ pub const SOFT_DELETE_ANY_BY_ID: &str =
     "UPDATE iqps SET approve_status=false, is_deleted = true WHERE id=$1";
 
 /// Hard deletes a paper (removes it from the database)
-pub const HARD_DELETE_BY_ID: &str =
-    "DELETE FROM iqps WHERE id=$1";
+pub const HARD_DELETE_BY_ID: &str = "DELETE FROM iqps WHERE id=$1";
 
 /// Gets all soft-deleted papers ([`crate::db::models::DBAdminDashboardQP`]) from the database
 pub fn get_get_soft_deleted_papers_query() -> String {
-    format!("SELECT {} FROM iqps WHERE is_deleted=true", ADMIN_DASHBOARD_QP_FIELDS)
+    format!(
+        "SELECT {} FROM iqps WHERE is_deleted=true",
+        ADMIN_DASHBOARD_QP_FIELDS
+    )
 }
 
 /// Get a paper ([`crate::db::models::DBAdminDashboardQP`]) with the given id (first parameter `$1`)
@@ -128,12 +130,12 @@ pub const GET_UNAPPROVED_COUNT: &str =
 /// Returns the query and a boolean representing whether the second argument is required
 pub fn get_qp_search_query(exam_filter: Vec<Exam>) -> String {
     let exam_filter_clause = exam_filter
-        .iter()
-        .map(|&exam| {
+        .into_iter()
+        .map(|exam| {
             if let Exam::CT(_) = exam {
                 "exam LIKE 'ct%'".into()
             } else {
-                format!("exam = '{}'", String::from(exam))
+                format!("exam = '{}'", String::from(&exam))
             }
         })
         .collect::<Vec<String>>()

--- a/backend/src/db/queries.rs
+++ b/backend/src/db/queries.rs
@@ -130,12 +130,12 @@ pub const GET_UNAPPROVED_COUNT: &str =
 /// Returns the query and a boolean representing whether the second argument is required
 pub fn get_qp_search_query(exam_filter: Vec<Exam>) -> String {
     let exam_filter_clause = exam_filter
-        .into_iter()
+        .iter()
         .map(|exam| {
             if let Exam::CT(_) = exam {
                 "exam LIKE 'ct%'".into()
             } else {
-                format!("exam = '{}'", String::from(&exam))
+                format!("exam = '{}'", String::from(exam))
             }
         })
         .collect::<Vec<String>>()

--- a/backend/src/env.rs
+++ b/backend/src/env.rs
@@ -9,7 +9,6 @@ use sha2::Sha256;
 
 use crate::pathutils::Paths;
 
-#[derive(Clone)]
 pub struct EnvVars {
     // Database
     /// Database name
@@ -37,7 +36,7 @@ pub struct EnvVars {
     /// The usernames of the admins (additional to org team members, comma separated)
     pub gh_admin_usernames: String,
     /// URL of Slack webhook for sending notifications
-    pub slack_webhook_url: String, 
+    pub slack_webhook_url: String,
 
     // Other configs
     /// Maximum number of papers that can be uploaded at a time
@@ -67,7 +66,7 @@ pub struct EnvVars {
     pub paths: Paths,
 }
 
-impl EnvVars {    
+impl EnvVars {
     /// Parses the environment variables into the struct
     pub fn parse() -> Result<Self, Box<dyn std::error::Error>> {
         let db_name = std::env::var("DB_NAME")?;
@@ -128,7 +127,7 @@ impl EnvVars {
             paths: Paths::default(),
         })
     }
-    
+
     /// Processes the environment variables after reading.
     pub fn process(mut self) -> Result<Self, Box<dyn std::error::Error>> {
         self.paths = Paths::new(

--- a/backend/src/env.rs
+++ b/backend/src/env.rs
@@ -81,28 +81,29 @@ impl EnvVars {
         let gh_org_team_slug = std::env::var("GH_ORG_TEAM_SLUG").unwrap_or_default();
         let gh_admin_usernames = std::env::var("GH_ADMIN_USERNAMES").unwrap_or_default();
         let slack_webhook_url = std::env::var("SLACK_WEBHOOK_URL").unwrap_or_default();
-        let max_upload_limit = std::env::var("MAX_UPLOAD_LIMIT")
-            .unwrap_or_else(|_| "10".to_string())
-            .parse::<usize>()?;
+        let max_upload_limit: usize = std::env::var("MAX_UPLOAD_LIMIT")
+            .map(|s| s.parse())
+            .unwrap_or(Ok(10))?;
         let log_location = std::env::var("LOG_LOCATION")
-            .unwrap_or_else(|_| "./log/application.log".to_string())
+            .unwrap_or("./log/application.log".to_string())
             .into();
-        let static_files_url = std::env::var("STATIC_FILES_URL")
-            .unwrap_or_else(|_| "https://static.metakgp.org".to_string());
+        let static_files_url =
+            std::env::var("STATIC_FILES_URL").unwrap_or("https://static.metakgp.org".to_string());
         let static_file_storage_location = std::env::var("STATIC_FILE_STORAGE_LOCATION")
-            .unwrap_or_else(|_| "/srv/static".to_string())
+            .unwrap_or("/srv/static".to_string())
             .into();
         let uploaded_qps_path = std::env::var("UPLOADED_QPS_PATH")
-            .unwrap_or_else(|_| "/iqps/uploaded".to_string())
+            .unwrap_or("/iqps/uploaded".to_string())
             .into();
         let library_qps_path = std::env::var("LIBRARY_QPS_PATH")
-            .unwrap_or_else(|_| "/peqp/qp".to_string())
+            .unwrap_or("/peqp/qp".to_string())
             .into();
-        let server_port = std::env::var("SERVER_PORT")
-            .unwrap_or_else(|_| "8080".to_string())
-            .parse::<i32>()?;
+        let server_port: i32 = std::env::var("SERVER_PORT")
+            .map(|s| s.parse())
+            .unwrap_or(Ok(8080))?;
         let cors_allowed_origins = std::env::var("CORS_ALLOWED_ORIGINS")
-            .unwrap_or_else(|_| "https://qp.metakgp.org,http://localhost:5173".to_string());
+            .unwrap_or("https://qp.metakgp.org,http://localhost:5173".to_string());
+
         Ok(Self {
             db_name,
             db_host,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -5,13 +5,7 @@
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::prelude::*;
 
-mod auth;
-mod db;
-mod env;
-mod pathutils;
-mod qp;
-mod routing;
-mod slack;
+use iqps_backend::{db, env, routing};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let listener =
         tokio::net::TcpListener::bind(format!("0.0.0.0:{}", env_vars.server_port)).await?;
     tracing::info!("Starting server on port {}", env_vars.server_port);
-    axum::serve(listener, routing::get_router(&env_vars, database)).await?;
+    axum::serve(listener, routing::get_router(env_vars, database)).await?;
 
     Ok(())
 }

--- a/backend/src/pathutils.rs
+++ b/backend/src/pathutils.rs
@@ -9,7 +9,6 @@ use std::{
 use color_eyre::eyre::eyre;
 use url::Url;
 
-#[allow(unused)]
 /// A category of papers, can also be used to represent the directory where these papers are stored
 pub enum PaperCategory {
     /// Unapproved paper
@@ -49,9 +48,6 @@ pub struct Paths {
     /// The absolute path to the location from where the static files server serves files
     static_files_path: PathBuf,
 
-    /// The absolute system paths to all three directories on the server
-    system_paths: PathTriad,
-
     /// The slugs to all three directories
     ///
     /// A slug is a relative path independent of the URL or system path. This slug is stored in the database and either the [`crate::pathutils::Paths::static_files_url`] or the [`crate::pathutils::Paths::static_files_path`] is prepended to it to get its URL (to send to the frontend) or the system path (for backend operations)
@@ -64,13 +60,11 @@ impl Default for Paths {
             static_files_url: Url::parse("https://metakgp.org")
                 .expect("This library thinks https://metakgp.org is not a valid URL."),
             static_files_path: PathBuf::default(),
-            system_paths: PathTriad::default(),
             path_slugs: PathTriad::default(),
         }
     }
 }
 
-#[allow(unused)]
 impl Paths {
     /// Creates a new `Paths` struct
     /// # Arguments
@@ -128,7 +122,6 @@ impl Paths {
         Ok(Self {
             static_files_url: Url::parse(static_files_url)?,
             static_files_path: path::absolute(static_file_storage_location)?,
-            system_paths,
             path_slugs,
         })
     }
@@ -142,30 +135,9 @@ impl Paths {
             .to_string()
     }
 
-    /// Returns the absolute system path for the specified directory and filename
-    pub fn get_path(&self, filename: &str, dir: PaperCategory) -> PathBuf {
-        self.system_paths.get(dir).join(filename)
-    }
-
     /// Returns the absolute system path from a given slug
     pub fn get_path_from_slug(&self, slug: &str) -> PathBuf {
         self.static_files_path.join(slug)
-    }
-
-    /// Returns the static server URL for the specified directory and filename
-    pub fn get_url(
-        &self,
-        filename: &str,
-        dir: PaperCategory,
-    ) -> Result<String, color_eyre::eyre::Error> {
-        let slug = self
-            .path_slugs
-            .get(dir)
-            .join(filename)
-            .to_string_lossy()
-            .into_owned();
-
-        self.get_url_from_slug(&slug)
     }
 
     /// Returns the static server URL for a given slug

--- a/backend/src/pathutils.rs
+++ b/backend/src/pathutils.rs
@@ -9,8 +9,8 @@ use std::{
 use color_eyre::eyre::eyre;
 use url::Url;
 
-/// A category of papers, can also be used to represent the directory where these papers are stored
 #[allow(unused)]
+/// A category of papers, can also be used to represent the directory where these papers are stored
 pub enum PaperCategory {
     /// Unapproved paper
     Unapproved,
@@ -20,7 +20,7 @@ pub enum PaperCategory {
     Library,
 }
 
-#[derive(Clone, Default)]
+#[derive(Default)]
 /// A set of paths (absolute, relative, or even URLs) for all three categories of papers (directories)
 struct PathTriad {
     /// Unapproved paper path
@@ -42,8 +42,6 @@ impl PathTriad {
     }
 }
 
-#[derive(Clone)]
-#[allow(unused)]
 /// Struct containing all the paths and URLs required to parse or create any question paper's slug, absolute path, or URL.
 pub struct Paths {
     /// URL of the static files server

--- a/backend/src/qp.rs
+++ b/backend/src/qp.rs
@@ -130,12 +130,11 @@ pub struct LibraryQP {
     pub year: i32,
     pub exam: String,
     pub semester: String,
-    #[allow(dead_code)]
     pub filename: String,
     pub approve_status: bool,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, sqlx::FromRow)]
 /// The fields of a question paper sent from the search endpoint
 pub struct BaseQP {
     pub id: i32,
@@ -149,12 +148,13 @@ pub struct BaseQP {
     pub note: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, sqlx::FromRow)]
 /// The fields of a question paper sent from the admin dashboard endpoints.
 ///
 /// This includes fields such as `approve_status` and `upload_timestamp` that would only be relevant to the dashboard.
 pub struct AdminDashboardQP {
     #[serde(flatten)]
+    #[sqlx(flatten)]
     pub qp: BaseQP,
     pub upload_timestamp: String,
     pub approve_status: bool,

--- a/backend/src/qp.rs
+++ b/backend/src/qp.rs
@@ -148,6 +148,7 @@ pub struct BaseQP {
     pub note: String,
 }
 
+
 #[derive(Serialize, sqlx::FromRow)]
 /// The fields of a question paper sent from the admin dashboard endpoints.
 ///
@@ -155,8 +156,10 @@ pub struct BaseQP {
 pub struct AdminDashboardQP {
     #[serde(flatten)]
     #[sqlx(flatten)]
+    /// The basic question paper fields, inherited from the `BaseQP` type. This field is flattened
+    /// for JSON serialization.
     pub qp: BaseQP,
-    pub upload_timestamp: String,
+    pub upload_timestamp: chrono::NaiveDateTime,
     pub approve_status: bool,
 }
 

--- a/backend/src/qp.rs
+++ b/backend/src/qp.rs
@@ -7,7 +7,6 @@ use serde::Serialize;
 
 use crate::env::EnvVars;
 
-#[derive(Clone, Copy)]
 /// Represents a semester.
 ///
 /// It can be parsed from a [`String`] using the `.try_from()` function. An error will be returned if the given string has an invalid value.
@@ -24,10 +23,10 @@ pub enum Semester {
     Unknown,
 }
 
-impl TryFrom<&String> for Semester {
+impl TryFrom<&str> for Semester {
     type Error = color_eyre::eyre::Error;
 
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
         if value == "autumn" {
             Ok(Semester::Autumn)
         } else if value == "spring" {
@@ -40,8 +39,8 @@ impl TryFrom<&String> for Semester {
     }
 }
 
-impl From<Semester> for String {
-    fn from(value: Semester) -> Self {
+impl From<&Semester> for String {
+    fn from(value: &Semester) -> Self {
         match value {
             Semester::Autumn => "autumn".into(),
             Semester::Spring => "spring".into(),
@@ -50,7 +49,6 @@ impl From<Semester> for String {
     }
 }
 
-#[derive(Clone, Copy)]
 /// Represents the exam type of the paper.
 ///
 /// Can be converted to and parsed from a String using the [`From`] and [`TryFrom`] trait implementations.
@@ -69,10 +67,10 @@ pub enum Exam {
     Unknown,
 }
 
-impl TryFrom<&String> for Exam {
+impl TryFrom<&str> for Exam {
     type Error = color_eyre::eyre::Error;
 
-    fn try_from(value: &String) -> Result<Self, Self::Error> {
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
         if value == "midsem" {
             Ok(Exam::Midsem)
         } else if value == "endsem" {
@@ -93,8 +91,8 @@ impl TryFrom<&String> for Exam {
     }
 }
 
-impl From<Exam> for String {
-    fn from(value: Exam) -> Self {
+impl From<&Exam> for String {
+    fn from(value: &Exam) -> Self {
         match value {
             Exam::Midsem => "midsem".into(),
             Exam::Endsem => "endsem".into(),
@@ -115,7 +113,7 @@ impl Serialize for Serializable {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&String::from(*self))
+        serializer.serialize_str(String::from(self).as_str())
     }
 }
 
@@ -137,7 +135,7 @@ pub struct LibraryQP {
     pub approve_status: bool,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize)]
 /// The fields of a question paper sent from the search endpoint
 pub struct BaseQP {
     pub id: i32,
@@ -151,7 +149,7 @@ pub struct BaseQP {
     pub note: String,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize)]
 /// The fields of a question paper sent from the admin dashboard endpoints.
 ///
 /// This includes fields such as `approve_status` and `upload_timestamp` that would only be relevant to the dashboard.

--- a/backend/src/routing/handlers.rs
+++ b/backend/src/routing/handlers.rs
@@ -274,7 +274,7 @@ pub struct UploadStatus {
     /// The filename
     filename: String,
     /// Whether the file was successfully uploaded
-    status: String,
+    status: &'static str,
     /// A message describing the status
     message: String,
 }
@@ -283,7 +283,7 @@ impl UploadStatus {
     fn ok(filename: String) -> Self {
         Self {
             filename,
-            status: "success".into(),
+            status: "success",
             message: "Successfully uploaded paper.".into(),
         }
     }
@@ -291,7 +291,7 @@ impl UploadStatus {
     fn error(filename: String, message: String) -> Self {
         Self {
             filename,
-            status: "error".into(),
+            status: "error",
             message,
         }
     }
@@ -484,23 +484,23 @@ pub struct HardDeleteReq {
 /// The status of a paper to be deleted
 pub struct DeleteStatus {
     id: i32,
-    status: String,
-    message: String,
+    status: &'static str,
+    message: &'static str,
 }
 
 impl DeleteStatus {
     fn ok(id: i32) -> Self {
         Self {
             id,
-            status: "success".into(),
-            message: "Successfully hard deleted the paper.".into(),
+            status: "success",
+            message: "Successfully hard deleted the paper.",
         }
     }
 
-    fn error(id: i32, message: String) -> Self {
+    fn error(id: i32, message: &'static str) -> Self {
         Self {
             id,
-            status: "error".into(),
+            status: "error",
             message,
         }
     }
@@ -524,14 +524,12 @@ pub async fn hard_delete(
                     delete_statuses.push(DeleteStatus::ok(id));
                     deleted_count += 1;
                 } else {
-                    delete_statuses.push(DeleteStatus::error(
-                        id,
-                        "Error committing the transaction.".into(),
-                    ));
+                    delete_statuses
+                        .push(DeleteStatus::error(id, "Error committing the transaction."));
                 }
             } else {
                 tx.rollback().await?;
-                delete_statuses.push(DeleteStatus::error(id, "Failed to delete file.".into()));
+                delete_statuses.push(DeleteStatus::error(id, "Failed to delete file."));
             }
         }
     }

--- a/backend/src/routing/handlers.rs
+++ b/backend/src/routing/handlers.rs
@@ -10,7 +10,7 @@ use axum::{
     http::StatusCode,
     Extension,
 };
-use color_eyre::eyre::{ContextCompat, Result};
+use color_eyre::eyre::{eyre, ContextCompat, Result};
 use http::HeaderMap;
 use serde::Serialize;
 use tokio::fs;
@@ -39,10 +39,9 @@ pub async fn healthcheck() -> HandlerReturn<()> {
 
 /// Fetches all the unapproved papers.
 pub async fn get_unapproved(State(state): HandlerState) -> HandlerReturn<Vec<AdminDashboardQP>> {
-    let papers: Vec<AdminDashboardQP> = state.db.get_unapproved_papers().await?;
+    let papers = state.db.get_unapproved_papers().await?;
 
     let papers = papers
-        .into_iter()
         .map(|paper| paper.with_url(&state.env_vars))
         .collect::<Result<Vec<qp::AdminDashboardQP>, color_eyre::eyre::Error>>()?;
 
@@ -54,10 +53,9 @@ pub async fn get_unapproved(State(state): HandlerState) -> HandlerReturn<Vec<Adm
 
 /// Gets all papers which have been soft-deleted.
 pub async fn get_trash(State(state): HandlerState) -> HandlerReturn<Vec<AdminDashboardQP>> {
-    let papers: Vec<AdminDashboardQP> = state.db.get_soft_deleted_papers().await?;
+    let papers = state.db.get_soft_deleted_papers().await?;
 
     let papers = papers
-        .into_iter()
         .map(|paper| paper.with_url(&state.env_vars))
         .collect::<Result<Vec<qp::AdminDashboardQP>, color_eyre::eyre::Error>>()?;
 
@@ -115,10 +113,10 @@ pub async fn search(
             .map(Exam::try_from)
             .collect::<Result<Vec<Exam>, _>>()
         {
-            let papers = state.db.search_papers(query, exam_filter).await?;
-
-            let papers = papers
-                .into_iter()
+            let papers = state
+                .db
+                .search_papers(query, exam_filter)
+                .await?
                 .map(|paper| paper.with_url(&state.env_vars))
                 .collect::<Result<Vec<qp::BaseQP>, color_eyre::eyre::Error>>()?;
 
@@ -307,8 +305,11 @@ pub async fn upload(
     let mut files = Vec::<(HeaderMap, Bytes)>::new();
     let mut file_details: String = "".into();
 
-    while let Some(field) = multipart.next_field().await.unwrap() {
-        let name = field.name().unwrap().to_string();
+    while let Some(field) = multipart.next_field().await? {
+        let name = field
+            .name()
+            .ok_or(eyre!("Error parsing file upload multipart field."))?
+            .to_string();
 
         if name == "files" {
             files.push((field.headers().clone(), field.bytes().await?));
@@ -573,13 +574,12 @@ pub async fn similar(
             body.get("semester"),
             body.get("exam"),
         )
-        .await?;
+        .await?
+        .map(|paper| paper.with_url(&state.env_vars))
+        .collect::<Result<Vec<AdminDashboardQP>>>()?;
 
     Ok(BackendResponse::ok(
         format!("Found {} similar papers.", papers.len()),
-        papers
-            .into_iter()
-            .map(|paper| paper.with_url(&state.env_vars))
-            .collect::<Result<Vec<AdminDashboardQP>>>()?,
+        papers,
     ))
 }

--- a/backend/src/routing/handlers.rs
+++ b/backend/src/routing/handlers.rs
@@ -42,6 +42,7 @@ pub async fn get_unapproved(State(state): HandlerState) -> HandlerReturn<Vec<Adm
     let papers = state.db.get_unapproved_papers().await?;
 
     let papers = papers
+        .into_iter()
         .map(|paper| paper.with_url(&state.env_vars))
         .collect::<Result<Vec<qp::AdminDashboardQP>, color_eyre::eyre::Error>>()?;
 
@@ -56,6 +57,7 @@ pub async fn get_trash(State(state): HandlerState) -> HandlerReturn<Vec<AdminDas
     let papers = state.db.get_soft_deleted_papers().await?;
 
     let papers = papers
+        .into_iter()
         .map(|paper| paper.with_url(&state.env_vars))
         .collect::<Result<Vec<qp::AdminDashboardQP>, color_eyre::eyre::Error>>()?;
 
@@ -575,6 +577,7 @@ pub async fn similar(
             body.get("exam"),
         )
         .await?
+        .into_iter()
         .map(|paper| paper.with_url(&state.env_vars))
         .collect::<Result<Vec<AdminDashboardQP>>>()?;
 

--- a/backend/src/routing/handlers.rs
+++ b/backend/src/routing/handlers.rs
@@ -27,7 +27,7 @@ use crate::{
     slack::send_slack_message,
 };
 
-use super::{AppError, BackendResponse, HandlerState, Status};
+use super::{AppError, BackendResponse, HandlerState};
 
 /// The return type of a handler function. T is the data type returned if the operation was a success
 type HandlerReturn<T> = Result<(StatusCode, BackendResponse<T>), AppError>;
@@ -274,9 +274,27 @@ pub struct UploadStatus {
     /// The filename
     filename: String,
     /// Whether the file was successfully uploaded
-    status: Status,
+    status: String,
     /// A message describing the status
     message: String,
+}
+
+impl UploadStatus {
+    fn ok(filename: String) -> Self {
+        Self {
+            filename,
+            status: "success".into(),
+            message: "Successfully uploaded paper.".into(),
+        }
+    }
+
+    fn error(filename: String, message: String) -> Self {
+        Self {
+            filename,
+            status: "error".into(),
+            message,
+        }
+    }
 }
 
 /// Uploads question papers to the server
@@ -334,33 +352,29 @@ pub async fn upload(
         let filename = details.filename.clone();
 
         if file_data.len() > FILE_SIZE_LIMIT {
-            upload_statuses.push(UploadStatus {
+            upload_statuses.push(UploadStatus::error(
                 filename,
-                status: Status::Error,
-                message: format!(
+                format!(
                     "File size too big. Only files upto {} MiB are allowed.",
                     FILE_SIZE_LIMIT >> 20
                 ),
-            });
+            ));
             continue;
         }
 
         if let Some(content_type) = file_headers.get("content-type") {
             if content_type != "application/pdf" {
-                upload_statuses.push(UploadStatus {
+                upload_statuses.push(UploadStatus::error(
                     filename,
-                    status: Status::Error,
-                    message: "Only PDFs are supported.".into(),
-                });
+                    "Only PDFs are supported.".into(),
+                ));
                 continue;
             }
         } else {
-            upload_statuses.push(UploadStatus {
+            upload_statuses.push(UploadStatus::error(
                 filename,
-                status: Status::Error,
-                message: "`content-type` header not found. File type could not be determined."
-                    .into(),
-            });
+                "`content-type` header not found. File type could not be determined.".into(),
+            ));
             continue;
         }
 
@@ -385,20 +399,15 @@ pub async fn upload(
             // Write the file data
             if fs::write(&filepath, file_data).await.is_ok() {
                 if tx.commit().await.is_ok() {
-                    upload_statuses.push(UploadStatus {
-                        filename,
-                        status: Status::Success,
-                        message: "Succesfully uploaded file.".into(),
-                    });
+                    upload_statuses.push(UploadStatus::ok(filename));
                     continue;
                 } else {
                     // Transaction commit failed, delete the file
                     fs::remove_file(filepath).await?;
-                    upload_statuses.push(UploadStatus {
+                    upload_statuses.push(UploadStatus::error(
                         filename,
-                        status: Status::Success,
-                        message: "Succesfully uploaded file.".into(),
-                    });
+                        "Error: Database transaction failed.".into(),
+                    ));
                     continue;
                 }
             } else {
@@ -409,19 +418,15 @@ pub async fn upload(
         } else {
             tx.rollback().await?;
 
-            upload_statuses.push(UploadStatus {
+            upload_statuses.push(UploadStatus::error(
                 filename,
-                status: Status::Error,
-                message: "Error updating the filelink".into(),
-            });
+                "Error updating the filelink".into(),
+            ));
             continue;
         }
 
-        upload_statuses.push(UploadStatus {
-            filename,
-            status: Status::Error,
-            message: "THIS SHOULD NEVER HAPPEN. REPORT IMMEDIATELY. ALSO THIS WOULDN'T HAPPEN IF RUST HAD STABLE ASYNC CLOSURES.".into(),
-        });
+        upload_statuses.push(UploadStatus::error(filename,
+            "THIS SHOULD NEVER HAPPEN. REPORT IMMEDIATELY. ~~ALSO THIS WOULDN'T HAPPEN IF RUST HAD STABLE ASYNC CLOSURES.~~ CORRECTION: ASYNC CLOSURES ARE STABLE. THE ALTERNATIVE IS INSANE. THIS IS BETTER.".into()));
     }
 
     let total_count = state.db.get_unapproved_papers_count().await?;
@@ -479,8 +484,26 @@ pub struct HardDeleteReq {
 /// The status of a paper to be deleted
 pub struct DeleteStatus {
     id: i32,
-    status: Status,
+    status: String,
     message: String,
+}
+
+impl DeleteStatus {
+    fn ok(id: i32) -> Self {
+        Self {
+            id,
+            status: "success".into(),
+            message: "Successfully hard deleted the paper.".into(),
+        }
+    }
+
+    fn error(id: i32, message: String) -> Self {
+        Self {
+            id,
+            status: "error".into(),
+            message,
+        }
+    }
 }
 
 /// Hard deletes papers from a list of ids.
@@ -498,26 +521,17 @@ pub async fn hard_delete(
             let filepath = state.env_vars.paths.get_path_from_slug(&paper.qp.filelink);
             if fs::remove_file(&filepath).await.is_ok() {
                 if tx.commit().await.is_ok() {
-                    delete_statuses.push(DeleteStatus {
-                        id,
-                        status: Status::Success,
-                        message: "Successfully hard deleted the paper.".into(),
-                    });
+                    delete_statuses.push(DeleteStatus::ok(id));
                     deleted_count += 1;
                 } else {
-                    delete_statuses.push(DeleteStatus {
+                    delete_statuses.push(DeleteStatus::error(
                         id,
-                        status: Status::Error,
-                        message: "Error committing the transaction.".into(),
-                    });
+                        "Error committing the transaction.".into(),
+                    ));
                 }
             } else {
                 tx.rollback().await?;
-                delete_statuses.push(DeleteStatus {
-                    id,
-                    status: Status::Error,
-                    message: "Failed to delete file.".into(),
-                });
+                delete_statuses.push(DeleteStatus::error(id, "Failed to delete file.".into()));
             }
         }
     }

--- a/backend/src/routing/handlers.rs
+++ b/backend/src/routing/handlers.rs
@@ -119,6 +119,7 @@ pub async fn search(
                 .db
                 .search_papers(query, exam_filter)
                 .await?
+                .into_iter()
                 .map(|paper| paper.with_url(&state.env_vars))
                 .collect::<Result<Vec<qp::BaseQP>, color_eyre::eyre::Error>>()?;
 

--- a/backend/src/routing/handlers.rs
+++ b/backend/src/routing/handlers.rs
@@ -27,7 +27,7 @@ use crate::{
     slack::send_slack_message,
 };
 
-use super::{AppError, BackendResponse, RouterState, Status};
+use super::{AppError, BackendResponse, HandlerState, Status};
 
 /// The return type of a handler function. T is the data type returned if the operation was a success
 type HandlerReturn<T> = Result<(StatusCode, BackendResponse<T>), AppError>;
@@ -38,14 +38,12 @@ pub async fn healthcheck() -> HandlerReturn<()> {
 }
 
 /// Fetches all the unapproved papers.
-pub async fn get_unapproved(
-    State(state): State<RouterState>,
-) -> HandlerReturn<Vec<AdminDashboardQP>> {
+pub async fn get_unapproved(State(state): HandlerState) -> HandlerReturn<Vec<AdminDashboardQP>> {
     let papers: Vec<AdminDashboardQP> = state.db.get_unapproved_papers().await?;
 
     let papers = papers
-        .iter()
-        .map(|paper| paper.clone().with_url(&state.env_vars))
+        .into_iter()
+        .map(|paper| paper.with_url(&state.env_vars))
         .collect::<Result<Vec<qp::AdminDashboardQP>, color_eyre::eyre::Error>>()?;
 
     Ok(BackendResponse::ok(
@@ -55,12 +53,12 @@ pub async fn get_unapproved(
 }
 
 /// Gets all papers which have been soft-deleted.
-pub async fn get_trash(State(state): State<RouterState>) -> HandlerReturn<Vec<AdminDashboardQP>> {
+pub async fn get_trash(State(state): HandlerState) -> HandlerReturn<Vec<AdminDashboardQP>> {
     let papers: Vec<AdminDashboardQP> = state.db.get_soft_deleted_papers().await?;
 
     let papers = papers
-        .iter()
-        .map(|paper| paper.clone().with_url(&state.env_vars))
+        .into_iter()
+        .map(|paper| paper.with_url(&state.env_vars))
         .collect::<Result<Vec<qp::AdminDashboardQP>, color_eyre::eyre::Error>>()?;
 
     Ok(BackendResponse::ok(
@@ -71,7 +69,7 @@ pub async fn get_trash(State(state): State<RouterState>) -> HandlerReturn<Vec<Ad
 
 /// Fetches a paper by id.
 pub async fn get_paper_details(
-    State(state): State<RouterState>,
+    State(state): HandlerState,
     Query(params): Query<HashMap<String, String>>,
 ) -> HandlerReturn<AdminDashboardQP> {
     if let Some(id) = params.get("id") {
@@ -102,7 +100,7 @@ pub async fn get_paper_details(
 /// * `query`: The query string to search in the question papers (searches course name or code)
 /// * `exam` (optional): A comma-separated string of exam types to filter. Leave empty to match any exam.
 pub async fn search(
-    State(state): State<RouterState>,
+    State(state): HandlerState,
     Query(params): Query<HashMap<String, String>>,
 ) -> HandlerReturn<Vec<qp::BaseQP>> {
     let response = if let Some(query) = params.get("query") {
@@ -114,14 +112,14 @@ pub async fn search(
         if let Ok(exam_filter) = exam_query_str
             .split(',')
             .filter(|val| !val.trim().is_empty())
-            .map(|val| Exam::try_from(&val.to_owned()))
+            .map(Exam::try_from)
             .collect::<Result<Vec<Exam>, _>>()
         {
             let papers = state.db.search_papers(query, exam_filter).await?;
 
             let papers = papers
-                .iter()
-                .map(|paper| paper.clone().with_url(&state.env_vars))
+                .into_iter()
+                .map(|paper| paper.with_url(&state.env_vars))
                 .collect::<Result<Vec<qp::BaseQP>, color_eyre::eyre::Error>>()?;
 
             Ok(BackendResponse::ok(
@@ -160,7 +158,7 @@ pub struct OAuthRes {
 ///
 /// Request format - [`OAuthReq`]
 pub async fn oauth(
-    State(state): State<RouterState>,
+    State(state): HandlerState,
     Json(body): Json<OAuthReq>,
 ) -> HandlerReturn<OAuthRes> {
     if let Some(token) = auth::authenticate_user(&body.code, &state.env_vars).await? {
@@ -215,7 +213,7 @@ pub struct EditReq {
 /// Request format - [`EditReq`]
 pub async fn edit(
     Extension(auth): Extension<Auth>,
-    State(state): State<RouterState>,
+    State(state): HandlerState,
     Json(body): Json<EditReq>,
 ) -> HandlerReturn<AdminDashboardQP> {
     // Edit the database entry
@@ -285,7 +283,7 @@ pub struct UploadStatus {
 ///
 /// Request format - Multipart form with a `file_details` field of the format [`FileDetails`]
 pub async fn upload(
-    State(state): State<RouterState>,
+    State(state): HandlerState,
     mut multipart: Multipart,
 ) -> HandlerReturn<Vec<UploadStatus>> {
     let mut files = Vec::<(HeaderMap, Bytes)>::new();
@@ -329,11 +327,11 @@ pub async fn upload(
         ));
     }
 
-    let files_iter = files.iter().zip(file_details.iter());
+    let files_iter = files.into_iter().zip(file_details.into_iter());
     let mut upload_statuses = Vec::<UploadStatus>::new();
 
     for ((file_headers, file_data), details) in files_iter {
-        let filename = details.filename.to_owned();
+        let filename = details.filename.clone();
 
         if file_data.len() > FILE_SIZE_LIMIT {
             upload_statuses.push(UploadStatus {
@@ -350,7 +348,7 @@ pub async fn upload(
         if let Some(content_type) = file_headers.get("content-type") {
             if content_type != "application/pdf" {
                 upload_statuses.push(UploadStatus {
-                    filename: filename.to_owned(),
+                    filename,
                     status: Status::Error,
                     message: "Only PDFs are supported.".into(),
                 });
@@ -455,10 +453,7 @@ pub struct DeleteReq {
 /// (Soft) Deletes a given paper.
 ///
 /// Request format - [`DeleteReq`]
-pub async fn delete(
-    State(state): State<RouterState>,
-    Json(body): Json<DeleteReq>,
-) -> HandlerReturn<()> {
+pub async fn delete(State(state): HandlerState, Json(body): Json<DeleteReq>) -> HandlerReturn<()> {
     let paper_deleted = state.db.soft_delete(body.id).await?;
 
     if paper_deleted {
@@ -492,7 +487,7 @@ pub struct DeleteStatus {
 ///
 /// Request format - [`HardDeleteReq`]
 pub async fn hard_delete(
-    State(state): State<RouterState>,
+    State(state): HandlerState,
     Json(body): Json<HardDeleteReq>,
 ) -> HandlerReturn<Vec<DeleteStatus>> {
     let mut delete_statuses = Vec::<DeleteStatus>::new();
@@ -545,7 +540,7 @@ pub async fn hard_delete(
 /// * `semester` (optional): The semester (autumn/spring)
 /// * `exam` (optional): The exam field (midsem/endsem/ct)
 pub async fn similar(
-    State(state): State<RouterState>,
+    State(state): HandlerState,
     Query(body): Query<HashMap<String, String>>,
 ) -> HandlerReturn<Vec<AdminDashboardQP>> {
     if !body.contains_key("course_code") {
@@ -571,8 +566,8 @@ pub async fn similar(
     Ok(BackendResponse::ok(
         format!("Found {} similar papers.", papers.len()),
         papers
-            .iter()
-            .map(|paper| paper.to_owned().with_url(&state.env_vars))
+            .into_iter()
+            .map(|paper| paper.with_url(&state.env_vars))
             .collect::<Result<Vec<AdminDashboardQP>>>()?,
     ))
 }

--- a/backend/src/routing/middleware.rs
+++ b/backend/src/routing/middleware.rs
@@ -9,18 +9,18 @@ use http::{HeaderMap, StatusCode};
 
 use crate::auth;
 
-use super::{AppError, BackendResponse, RouterState};
+use super::{AppError, BackendResponse, HandlerState};
 
 /// Verifies the JWT and authenticates a user. If the JWT is invalid, the user is sent an unauthorized status code. If the JWT is valid, the authentication is added to the state.
 pub async fn verify_jwt_middleware(
-    State(state): State<RouterState>,
+    State(state): HandlerState,
     headers: HeaderMap,
     mut request: Request,
     next: Next,
 ) -> Result<Response, AppError> {
     if let Some(auth_header) = headers.get("Authorization") {
         if let Some(jwt) = auth_header.to_str()?.strip_prefix("Bearer ") {
-            let auth = auth::verify_token(jwt, &state.env_vars).await;
+            let auth = auth::verify_token(jwt.to_owned(), &state.env_vars).await;
 
             if let Ok(auth) = auth {
                 // If auth is fine, add it to the request extensions

--- a/backend/src/routing/mod.rs
+++ b/backend/src/routing/mod.rs
@@ -1,7 +1,9 @@
 //! Router, [`handlers`], [`middleware`], state, and response utils.
 
+use std::sync::Arc;
+
 use axum::{
-    extract::{DefaultBodyLimit, Json},
+    extract::{DefaultBodyLimit, Json, State},
     http::StatusCode,
     response::IntoResponse,
 };
@@ -23,11 +25,19 @@ mod middleware;
 pub use handlers::{EditReq, FileDetails};
 
 /// Returns the Axum router for IQPS
-pub fn get_router(env_vars: &EnvVars, db: Database) -> axum::Router {
-    let state = RouterState {
-        db,
-        env_vars: env_vars.clone(),
-    };
+pub fn get_router(env_vars: EnvVars, db: Database) -> axum::Router {
+    let cors_origins = env_vars
+        .cors_allowed_origins
+        .split(',')
+        .map(|origin| {
+            origin
+                .trim()
+                .parse::<HeaderValue>()
+                .expect("CORS Allowed Origins Invalid")
+        })
+        .collect::<Vec<HeaderValue>>();
+
+    let state = Arc::new(RouterState { db, env_vars });
 
     axum::Router::new()
         .route("/unapproved", axum::routing::get(handlers::get_unapproved))
@@ -58,37 +68,25 @@ pub fn get_router(env_vars: &EnvVars, db: Database) -> axum::Router {
             CorsLayer::new()
                 .allow_headers(Any)
                 .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS])
-                .allow_origin(
-                    env_vars
-                        .cors_allowed_origins
-                        .split(',')
-                        .map(|origin| {
-                            origin
-                                .trim()
-                                .parse::<HeaderValue>()
-                                .expect("CORS Allowed Origins Invalid")
-                        })
-                        .collect::<Vec<HeaderValue>>(),
-                ),
+                .allow_origin(cors_origins),
         )
 }
 
-#[derive(Clone)]
 /// The state of the axum router, containing the environment variables and the database connection.
 struct RouterState {
     pub db: db::Database,
     pub env_vars: EnvVars,
 }
+type HandlerState = State<Arc<RouterState>>;
 
-#[derive(Clone, Copy)]
 /// The status of a server response
 enum Status {
     Success,
     Error,
 }
 
-impl From<Status> for String {
-    fn from(value: Status) -> Self {
+impl From<&Status> for String {
+    fn from(value: &Status) -> Self {
         match value {
             Status::Success => "success".into(),
             Status::Error => "error".into(),
@@ -101,7 +99,7 @@ impl Serialize for Status {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&String::from(*self))
+        serializer.serialize_str(String::from(self).as_str())
     }
 }
 

--- a/backend/src/routing/mod.rs
+++ b/backend/src/routing/mod.rs
@@ -79,35 +79,11 @@ struct RouterState {
 }
 type HandlerState = State<Arc<RouterState>>;
 
-/// The status of a server response
-enum Status {
-    Success,
-    Error,
-}
-
-impl From<&Status> for String {
-    fn from(value: &Status) -> Self {
-        match value {
-            Status::Success => "success".into(),
-            Status::Error => "error".into(),
-        }
-    }
-}
-
-impl Serialize for Status {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(String::from(self).as_str())
-    }
-}
-
 /// Standard backend response format (serialized as JSON)
 #[derive(serde::Serialize)]
 struct BackendResponse<T: Serialize> {
     /// Whether the operation succeeded or failed
-    pub status: Status,
+    pub status: String,
     /// A message describing the state of the operation (success/failure message)
     pub message: String,
     /// Any optional data sent (only sent if the operation was a success)
@@ -120,7 +96,7 @@ impl<T: serde::Serialize> BackendResponse<T> {
         (
             StatusCode::OK,
             Self {
-                status: Status::Success,
+                status: "success".into(),
                 message,
                 data: Some(data),
             },
@@ -132,7 +108,7 @@ impl<T: serde::Serialize> BackendResponse<T> {
         (
             status_code,
             Self {
-                status: Status::Error,
+                status: "error".into(),
                 message,
                 data: None,
             },

--- a/backend/src/routing/mod.rs
+++ b/backend/src/routing/mod.rs
@@ -83,7 +83,7 @@ type HandlerState = State<Arc<RouterState>>;
 #[derive(serde::Serialize)]
 struct BackendResponse<T: Serialize> {
     /// Whether the operation succeeded or failed
-    pub status: String,
+    pub status: &'static str,
     /// A message describing the state of the operation (success/failure message)
     pub message: String,
     /// Any optional data sent (only sent if the operation was a success)
@@ -96,7 +96,7 @@ impl<T: serde::Serialize> BackendResponse<T> {
         (
             StatusCode::OK,
             Self {
-                status: "success".into(),
+                status: "success",
                 message,
                 data: Some(data),
             },
@@ -108,7 +108,7 @@ impl<T: serde::Serialize> BackendResponse<T> {
         (
             status_code,
             Self {
-                status: "error".into(),
+                status: "error",
                 message,
                 data: None,
             },


### PR DESCRIPTION
# Description
- Reduced `.clone()`, `.to_owned()` etc. everywhere.
- Replaced `.iter()` with `.into_iter()` to prevent cloning references like an idiot.
  - Returned iterators wherever possible to reduce collecting to vectors and immediately converting to iterators again.
- Used references where cloning is not done or is only done partially.
- Used owned values where the value was only used once instead of creating a reference and cloning.
- Used `&str` types instead of `&String`.
- Removed `Clone, Copy` derives from almost everything.
- Convert state to an `Arc` instead of cloning it every time.
- Replaced `Status` enum with just a `String`.
- Removed unused code and unnecessary `#[allow(unused)]`.
- Implemented the `sqlx::Type`, `sqlx::Decode` and `sqlx::Encode` traits for the question paper types
  - Converting to an intermediate `DBQuestionPaper` type is no longer required. `sqlx.query.as()` can be directly used.
- Overall, made old stupid code I had written slightly better.