### PR TITLE
feat: add stats to homepage

### DIFF
--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -372,13 +372,6 @@ impl Database {
         Ok(count.get(0))
     }
 
-    /// Get number of recently uploaded papers
-    pub async fn get_recent_uploads_count(&self) -> Result<i64, color_eyre::eyre::Error> {
-        let query = sqlx::query(queries::GET_RECENT_UPLOADS_COUNT);
-        let count = query.fetch_one(&self.connection).await?;
-        Ok(count.get(0))
-    }
-
     /// Get total number of courses
     pub async fn get_total_courses_count(&self) -> Result<i64, color_eyre::eyre::Error> {
         let query = sqlx::query(queries::GET_TOTAL_COURSES_COUNT);

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -1,7 +1,7 @@
 //! Database stuff. See submodules also.
 
 use color_eyre::eyre::eyre;
-use sqlx::{postgres::PgPoolOptions, prelude::FromRow, PgPool, Postgres, Transaction};
+use sqlx::{PgPool, Postgres, Row, Transaction, postgres::PgPoolOptions, prelude::FromRow};
 use std::time::Duration;
 
 use crate::{
@@ -363,5 +363,26 @@ impl Database {
         query.execute(&mut **tx).await?;
 
         Ok(())
+    }
+    
+    /// Get total number of approved papers
+    pub async fn get_approved_count(&self) -> Result<i64, color_eyre::eyre::Error> {
+        let query = sqlx::query(queries::GET_APPROVED_COUNT);
+        let count = query.fetch_one(&self.connection).await?;
+        Ok(count.get(0))
+    }
+
+    /// Get number of recently uploaded papers
+    pub async fn get_recent_uploads_count(&self) -> Result<i64, color_eyre::eyre::Error> {
+        let query = sqlx::query(queries::GET_RECENT_UPLOADS_COUNT);
+        let count = query.fetch_one(&self.connection).await?;
+        Ok(count.get(0))
+    }
+
+    /// Get total number of courses
+    pub async fn get_total_courses_count(&self) -> Result<i64, color_eyre::eyre::Error> {
+        let query = sqlx::query(queries::GET_TOTAL_COURSES_COUNT);
+        let count = query.fetch_one(&self.connection).await?;
+        Ok(count.get(0))
     }
 }

--- a/backend/src/db/queries.rs
+++ b/backend/src/db/queries.rs
@@ -209,3 +209,12 @@ pub const UPDATE_FILELINK: &str = "UPDATE iqps SET filelink=$2 WHERE id=$1";
 /// Insert a library pqper in the db
 /// Parameters in the following order: `course_code`, `course_name`, `year`, `exam`, `semester`, `note`, `filelink`, `approve_status`
 pub const INSERT_NEW_LIBRARY_QP: &str = "INSERT INTO iqps (course_code, course_name, year, exam, semester, note, filelink, from_library, approve_status) VALUES ($1, $2, $3, $4, $5, $6, $7, true, $8) RETURNING id";
+
+/// Get total number of approved papers
+pub const GET_APPROVED_COUNT: &str = "SELECT COUNT(*) FROM iqps WHERE approve_status = true AND is_deleted = false";
+
+/// Get number of recently uploaded papers (last 1 week)
+pub const GET_RECENT_UPLOADS_COUNT: &str = "SELECT COUNT(*) FROM iqps WHERE upload_timestamp > (now() - interval '1 week')";
+
+/// Get total number of courses
+pub const GET_TOTAL_COURSES_COUNT: &str = "SELECT COUNT(DISTINCT course_code) FROM iqps";

--- a/backend/src/db/queries.rs
+++ b/backend/src/db/queries.rs
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS iqps (
 	course_name TEXT NOT NULL DEFAULT '',
 	year INTEGER NOT NULL,
     exam TEXT NOT NULL DEFAULT '',
-    semester TEXT NOT NULL DEFAULT '',
+    semester VARCHAR NOT NULL DEFAULT '',
     note TEXT NOT NULL DEFAULT '',
     filelink TEXT NOT NULL,
     from_library BOOLEAN DEFAULT FALSE,
@@ -212,9 +212,6 @@ pub const INSERT_NEW_LIBRARY_QP: &str = "INSERT INTO iqps (course_code, course_n
 
 /// Get total number of approved papers
 pub const GET_APPROVED_COUNT: &str = "SELECT COUNT(*) FROM iqps WHERE approve_status = true AND is_deleted = false";
-
-/// Get number of recently uploaded papers (last 1 week)
-pub const GET_RECENT_UPLOADS_COUNT: &str = "SELECT COUNT(*) FROM iqps WHERE upload_timestamp > (now() - interval '1 week')";
 
 /// Get total number of courses
 pub const GET_TOTAL_COURSES_COUNT: &str = "SELECT COUNT(DISTINCT course_code) FROM iqps";

--- a/backend/src/routing/handlers.rs
+++ b/backend/src/routing/handlers.rs
@@ -591,14 +591,12 @@ pub async fn similar(
 #[derive(Serialize)]
 pub struct Stats {
     total_papers: i64,
-    recent_uploads: i64,
     total_courses: i64,
 }
 
 /// Get statistics about the database
 pub async fn get_stats(State(state): HandlerState) -> HandlerReturn<Stats> {
     let total_papers = state.db.get_approved_count().await?;
-    let recent_uploads = state.db.get_recent_uploads_count().await?;
     let total_courses = state.db.get_total_courses_count().await?;
-    Ok(BackendResponse::ok(format!("Found {} papers.", total_papers), Stats { total_papers, recent_uploads, total_courses }))
+    Ok(BackendResponse::ok(format!("Found {} papers.", total_papers), Stats { total_papers, total_courses }))
 }

--- a/backend/src/routing/handlers.rs
+++ b/backend/src/routing/handlers.rs
@@ -587,3 +587,18 @@ pub async fn similar(
         papers,
     ))
 }
+
+#[derive(Serialize)]
+pub struct Stats {
+    total_papers: i64,
+    recent_uploads: i64,
+    total_courses: i64,
+}
+
+/// Get statistics about the database
+pub async fn get_stats(State(state): HandlerState) -> HandlerReturn<Stats> {
+    let total_papers = state.db.get_approved_count().await?;
+    let recent_uploads = state.db.get_recent_uploads_count().await?;
+    let total_courses = state.db.get_total_courses_count().await?;
+    Ok(BackendResponse::ok(format!("Found {} papers.", total_papers), Stats { total_papers, recent_uploads, total_courses }))
+}

--- a/backend/src/routing/mod.rs
+++ b/backend/src/routing/mod.rs
@@ -55,6 +55,7 @@ pub fn get_router(env_vars: EnvVars, db: Database) -> axum::Router {
         .route("/oauth", axum::routing::post(handlers::oauth))
         .route("/healthcheck", axum::routing::get(handlers::healthcheck))
         .route("/search", axum::routing::get(handlers::search))
+        .route("/stats", axum::routing::get(handlers::get_stats))
         .layer(DefaultBodyLimit::max(2 << 20)) // Default limit of 2 MiB
         .route("/upload", axum::routing::post(handlers::upload))
         .layer(DefaultBodyLimit::max(50 << 20)) // 50 MiB limit for upload endpoint

--- a/frontend/src/components/Common/styles/common_styles.scss
+++ b/frontend/src/components/Common/styles/common_styles.scss
@@ -9,7 +9,7 @@
 }
 
 .header {
-	margin-bottom: 2rem;
+	margin-bottom: 1rem;
 	text-align: center;
 
 	.header-link {

--- a/frontend/src/components/Search/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm.tsx
@@ -26,6 +26,7 @@ function CourseSearchForm() {
 	const [success, setSuccess] = useState<boolean>(false);
 	const [awaitingResponse, setAwaitingResponse] = useState<boolean>(false);
 	const [msg, setMsg] = useState<string>('Search for something.');
+	const [stats, setStats] = useState<{ total_papers: number; recent_uploads: number; total_courses: number } | null>(null);
 
 	const courseInputRef = createRef<HTMLInputElement>();
 
@@ -73,12 +74,30 @@ function CourseSearchForm() {
 		window.history.replaceState(window.history.state, "", url);
 	}
 
+	useEffect(() => {
+		const fetchStats = async () => {
+			const response = await makeRequest('stats', 'get');
+			if (response.status === 'success') {
+				setStats(response.data);
+			} else {
+				console.error('Error loading stats:', response.message);
+			}
+		};
+
+		if (query === '') {
+			fetchStats();
+		}
+	}, [])
+
 	// Load results if the link has a query
 	useEffect(() => {
 		if (query !== '') {
 			fetchResults();
 		}
 	}, [])
+
+	const showStats = query === '' && !awaitingResponse && !success && searchResults.length === 0 && stats !== null;
+	const displayMsg = showStats ? '' : msg;
 
 	return <div className="search-form">
 		<form onSubmit={handleSubmit}>
@@ -113,8 +132,10 @@ function CourseSearchForm() {
 		<SearchResults
 			awaitingResults={awaitingResponse}
 			success={success}
-			msg={msg}
+			msg={displayMsg}
 			results={searchResults}
+			stats={stats}
+			showStats={showStats}
 		/>
 	</div>;
 }

--- a/frontend/src/components/Search/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm.tsx
@@ -26,7 +26,6 @@ function CourseSearchForm() {
 	const [success, setSuccess] = useState<boolean>(false);
 	const [awaitingResponse, setAwaitingResponse] = useState<boolean>(false);
 	const [msg, setMsg] = useState<string>('Search for something.');
-	const [stats, setStats] = useState<{ total_papers: number; recent_uploads: number; total_courses: number } | null>(null);
 
 	const courseInputRef = createRef<HTMLInputElement>();
 
@@ -74,30 +73,12 @@ function CourseSearchForm() {
 		window.history.replaceState(window.history.state, "", url);
 	}
 
-	useEffect(() => {
-		const fetchStats = async () => {
-			const response = await makeRequest('stats', 'get');
-			if (response.status === 'success') {
-				setStats(response.data);
-			} else {
-				console.error('Error loading stats:', response.message);
-			}
-		};
-
-		if (query === '') {
-			fetchStats();
-		}
-	}, [])
-
 	// Load results if the link has a query
 	useEffect(() => {
 		if (query !== '') {
 			fetchResults();
 		}
 	}, [])
-
-	const showStats = query === '' && !awaitingResponse && !success && searchResults.length === 0 && stats !== null;
-	const displayMsg = showStats ? '' : msg;
 
 	return <div className="search-form">
 		<form onSubmit={handleSubmit}>
@@ -132,10 +113,8 @@ function CourseSearchForm() {
 		<SearchResults
 			awaitingResults={awaitingResponse}
 			success={success}
-			msg={displayMsg}
+			msg={msg}
 			results={searchResults}
-			stats={stats}
-			showStats={showStats}
 		/>
 	</div>;
 }

--- a/frontend/src/components/Search/SearchResults.tsx
+++ b/frontend/src/components/Search/SearchResults.tsx
@@ -13,22 +13,11 @@ type SortOrder = 'ascending' | 'descending';
 type FilterByYear = number | null;
 type FilterFields = 'filterByYear' | 'sortBy' | 'sortOrder';
 
-interface IStatCard {
-	label: string;
-	value: number;
-}
-
 interface ISearchResultsProps {
 	awaitingResults: boolean;
 	success: boolean;
 	msg: string;
 	results: ISearchResult[];
-	stats: {
-		total_papers: number;
-		recent_uploads: number;
-		total_courses: number;
-	} | null;
-	showStats: boolean;
 }
 
 
@@ -97,31 +86,11 @@ function SearchResults(props: ISearchResultsProps) {
 	// To update when filters are changed
 	useEffect(updateDisplayedResults, [filterByYear, sortBy, sortOrder])
 
-	const statsCards: IStatCard[] = props.stats ? [
-		{ label: 'question papers', value: props.stats.total_papers },
-		{ label: 'recently uploaded', value: props.stats.recent_uploads },
-		{ label: 'courses covered', value: props.stats.total_courses },
-	] : [];
-
-	const fmt = (num: number) => {
-		if (num >= 1000) return (num / 1000).toFixed(0) + 'k';
-		else return num;
-	}
-
 	return <div className="search-results">
 		{
 			props.awaitingResults ? <div className="spinner"><Spinner /></div> :
 				!props.success ? (
-					props.showStats && statsCards.length > 0 ? (
-						<div className="stats-panel">
-							{statsCards.map((stat, index) => (
-								<div key={index} className="stat-card">
-									<span className="stat-card-value">{fmt(stat.value)}</span>
-									<span className="stat-card-label">{stat.label}</span>
-								</div>
-							))}
-						</div>
-					) : <p className="message">{props.msg}</p>
+					<p className="message">{props.msg}</p>
 				) : (
 					<>
 						<ResultsFilter
@@ -237,7 +206,7 @@ function ResultCard(result: ISearchResult) {
 	}
 
 	return <div className="result-card">
-		<p className="result-card-info">
+		<div className="result-card-info">
 			<p className="result-card-title">{getTitle()}</p>
 			<div className="result-card-tags">
 				<span className="result-card-tag">{result.year}</span>
@@ -246,7 +215,7 @@ function ResultCard(result: ISearchResult) {
 				{result.note !== "" && <span className="result-card-tag">{result.note}</span>}
 				{auth.isAuthenticated && <span className="result-card-tag">id: {result.id}</span>}
 			</div>
-		</p>
+		</div>
 		<div className="result-card-btns">
 			{auth.isAuthenticated && <a
 				className="result-card-btn icon-btn"

--- a/frontend/src/components/Search/SearchResults.tsx
+++ b/frontend/src/components/Search/SearchResults.tsx
@@ -13,12 +13,25 @@ type SortOrder = 'ascending' | 'descending';
 type FilterByYear = number | null;
 type FilterFields = 'filterByYear' | 'sortBy' | 'sortOrder';
 
+interface IStatCard {
+	label: string;
+	value: number;
+}
+
 interface ISearchResultsProps {
 	awaitingResults: boolean;
 	success: boolean;
 	msg: string;
 	results: ISearchResult[];
+	stats: {
+		total_papers: number;
+		recent_uploads: number;
+		total_courses: number;
+	} | null;
+	showStats: boolean;
 }
+
+
 function SearchResults(props: ISearchResultsProps) {
 	const [displayedResults, setDisplayedResults] = useState<ISearchResult[]>(props.results);
 	const [filterByYear, setFilterByYear] = useState<FilterByYear>(null);
@@ -84,10 +97,32 @@ function SearchResults(props: ISearchResultsProps) {
 	// To update when filters are changed
 	useEffect(updateDisplayedResults, [filterByYear, sortBy, sortOrder])
 
+	const statsCards: IStatCard[] = props.stats ? [
+		{ label: 'question papers', value: props.stats.total_papers },
+		{ label: 'recently uploaded', value: props.stats.recent_uploads },
+		{ label: 'courses covered', value: props.stats.total_courses },
+	] : [];
+
+	const fmt = (num: number) => {
+		if (num >= 1000) return (num / 1000).toFixed(0) + 'k';
+		else return num;
+	}
+
 	return <div className="search-results">
 		{
 			props.awaitingResults ? <div className="spinner"><Spinner /></div> :
-				!props.success ? <p className="message">{props.msg}</p> : (
+				!props.success ? (
+					props.showStats && statsCards.length > 0 ? (
+						<div className="stats-panel">
+							{statsCards.map((stat, index) => (
+								<div key={index} className="stat-card">
+									<span className="stat-card-value">{fmt(stat.value)}</span>
+									<span className="stat-card-label">{stat.label}</span>
+								</div>
+							))}
+						</div>
+					) : <p className="message">{props.msg}</p>
+				) : (
 					<>
 						<ResultsFilter
 							filterByYear={filterByYear}

--- a/frontend/src/components/Search/Stats.tsx
+++ b/frontend/src/components/Search/Stats.tsx
@@ -20,9 +20,14 @@ function StatsShowcase() {
     fetchStats();
   }, []);
 
+  const fmt = (num: number) => {
+    if (num > 1000) return `${(num / 1000).toFixed(0)}k`;
+    return num;
+  }
+
   return (
     <div className="stats-panel">
-        Serving <span className="stat-value">{stats ? stats.total_papers : "..."}</span> question papers across <span className="stat-value">{stats ? stats.total_courses : "..."}</span> courses
+        Serving <span className="stat-value">{stats ? fmt(stats.total_papers) : "..."}</span> question papers across <span className="stat-value">{stats ? fmt(stats.total_courses) : "..."}</span> courses
     </div>
   );
 }

--- a/frontend/src/components/Search/Stats.tsx
+++ b/frontend/src/components/Search/Stats.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { makeRequest } from "../../utils/backend";
+import "./stats.scss";
+
+function StatsShowcase() {
+  const [stats, setStats] = useState<{
+    total_papers: number;
+    total_courses: number;
+  } | null>(null);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      const response = await makeRequest("stats", "get");
+      if (response.status === "success") {
+        setStats(response.data);
+      } else {
+        console.error("Error loading stats:", response.message);
+      }
+    };
+    fetchStats();
+  }, []);
+
+  return (
+    <div className="stats-panel">
+        Serving <span className="stat-value">{stats ? stats.total_papers : "..."}</span> question papers across <span className="stat-value">{stats ? stats.total_courses : "..."}</span> courses
+    </div>
+  );
+}
+
+export default StatsShowcase;

--- a/frontend/src/components/Search/search_results.scss
+++ b/frontend/src/components/Search/search_results.scss
@@ -16,6 +16,40 @@
 		font-size: 1.2rem;
 	}
 
+	.stats-panel {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 1rem;
+		margin: 1rem 0;
+	}
+
+	.stat-card {
+		background-color: $surface-2;
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		padding: 1rem 1.25rem;
+		border-radius: 12px;
+		min-width: 180px;
+		flex: 1 1 180px;
+		max-width: 280px;
+		text-align: center;
+		box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+	}
+
+	.stat-card-value {
+		display: block;
+		font-size: 2rem;
+		font-weight: 700;
+		color: $accent-color-lighter;
+	}
+
+	.stat-card-label {
+		display: block;
+		margin-top: 0.5rem;
+		color: $fg-color-darker;
+		font-size: 0.95rem;
+	}
+
 	.results-filter {
 		width: 100%;
 		display: flex;
@@ -104,6 +138,35 @@
 
 	@media only screen and (max-width: 768px) {
 		padding: 0.5rem 0;
+
+		.stats-panel {
+			flex-direction: column;
+		}
+
+		.stat-card {
+			max-width: none;
+			margin: 0 1rem;
+			flex: 1;
+			display: flex;
+			align-items: center;
+			gap: 1rem;
+			padding: 0;
+		}
+		
+		.stat-card-value, .stat-card-label {
+			font-size: 1rem;
+			margin: 0;
+			flex: 1;
+		}
+
+		.stat-card-value {
+			max-width: 60px;
+		}
+
+		.stat-card-label {
+			text-align: left;
+		}
+
 
 		.results-filter {
 			gap: 0rem;

--- a/frontend/src/components/Search/search_results.scss
+++ b/frontend/src/components/Search/search_results.scss
@@ -16,40 +16,6 @@
 		font-size: 1.2rem;
 	}
 
-	.stats-panel {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: center;
-		gap: 1rem;
-		margin: 1rem 0;
-	}
-
-	.stat-card {
-		background-color: $surface-2;
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		padding: 1rem 1.25rem;
-		border-radius: 12px;
-		min-width: 180px;
-		flex: 1 1 180px;
-		max-width: 280px;
-		text-align: center;
-		box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
-	}
-
-	.stat-card-value {
-		display: block;
-		font-size: 2rem;
-		font-weight: 700;
-		color: $accent-color-lighter;
-	}
-
-	.stat-card-label {
-		display: block;
-		margin-top: 0.5rem;
-		color: $fg-color-darker;
-		font-size: 0.95rem;
-	}
-
 	.results-filter {
 		width: 100%;
 		display: flex;
@@ -138,34 +104,6 @@
 
 	@media only screen and (max-width: 768px) {
 		padding: 0.5rem 0;
-
-		.stats-panel {
-			flex-direction: column;
-		}
-
-		.stat-card {
-			max-width: none;
-			margin: 0 1rem;
-			flex: 1;
-			display: flex;
-			align-items: center;
-			gap: 1rem;
-			padding: 0;
-		}
-		
-		.stat-card-value, .stat-card-label {
-			font-size: 1rem;
-			margin: 0;
-			flex: 1;
-		}
-
-		.stat-card-value {
-			max-width: 60px;
-		}
-
-		.stat-card-label {
-			text-align: left;
-		}
 
 
 		.results-filter {

--- a/frontend/src/components/Search/stats.scss
+++ b/frontend/src/components/Search/stats.scss
@@ -1,0 +1,24 @@
+@import "../../styles/variables";
+
+
+.stats-panel {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.8rem;
+}
+
+.stat-value {
+    display: inline-block;
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: $accent-color-lighter;
+}
+
+
+
+@media only screen and (max-width: 768px) {
+    .stats-panel {
+        margin-bottom: 1.25rem;
+    }
+}

--- a/frontend/src/components/Search/stats.scss
+++ b/frontend/src/components/Search/stats.scss
@@ -2,10 +2,7 @@
 
 
 .stats-panel {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 0.8rem;
+    text-align: center;
 }
 
 .stat-value {
@@ -20,5 +17,9 @@
 @media only screen and (max-width: 768px) {
     .stats-panel {
         margin-bottom: 1.25rem;
+    }
+
+    .stat-value {
+        font-size: 1rem;
     }
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,6 +1,8 @@
 import { Header } from "../components/Common/Common";
 import { FaUpload } from "react-icons/fa6";
 import CourseSearchForm from "../components/Search/SearchForm";
+import StatsShowcase from "../components/Search/Stats";
+
 
 function SearchPage() {
 	return <>
@@ -14,6 +16,7 @@ function SearchPage() {
 				button_text: "Upload!"
 			}}
 		/>
+		<StatsShowcase />
 		<CourseSearchForm />
 	</>;
 }

--- a/frontend/src/styles/index.scss
+++ b/frontend/src/styles/index.scss
@@ -83,3 +83,9 @@ select,
 
 	border-radius: 10px !important;
 }
+
+@media only screen and (max-width: 768px) {
+    :root {
+		font-size: 11pt;
+	}
+}

--- a/frontend/src/types/backend.ts
+++ b/frontend/src/types/backend.ts
@@ -106,7 +106,6 @@ export interface IEndpointTypes {
 		request: null;
 		response: {
 			total_papers: number;
-			recent_uploads: number;
 			total_courses: number;
 		}
 	},

--- a/frontend/src/types/backend.ts
+++ b/frontend/src/types/backend.ts
@@ -101,5 +101,13 @@ export interface IEndpointTypes {
 			exam?: Exam;
 		},
 		response: IAdminDashboardQP[];
-	}
+	},
+	stats: {
+		request: null;
+		response: {
+			total_papers: number;
+			recent_uploads: number;
+			total_courses: number;
+		}
+	},
 }


### PR DESCRIPTION
# Description
Added statistics to the homepage which is visible before searching.
- total (approved) question papers
- total unique courses covered

<details><summary> Screenshots</summary>
<img width="1360" height="904" alt="image" src="https://github.com/user-attachments/assets/8b1960c2-8937-4d2d-8bd3-0bd3e367b8e0" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/d7bda7db-2ad5-4541-80e2-22025e39283a" />
</details>

Fixes #142 

- [x] I have updated the relevant documentation
